### PR TITLE
Add documentation about JSON date format, timezone, quote factor fields

### DIFF
--- a/docs/de/how-to/historische-aktienkurse/json.md
+++ b/docs/de/how-to/historische-aktienkurse/json.md
@@ -323,3 +323,13 @@ Abbildung: Finale Settings Portfolio Performance Onvista JSON {class="pp-figure"
 ![](images/screenshot_onvista_json_settings_pp_final.png)
 
 
+### Weitere Angaben
+
+#### Datumsformat
+Portfolio Performance erkennt gängige Arten, ein Datum darzustellen, automatisch. Dazu gehören insbesondere ISO-Datenangaben (z. B. 2025-06-21) und UNIX Timestamps (die Anzahl von Sekunden seit Mitternacht 01.01.1970, UTC). Sollte eine API das Datum auf eine andere Weise darstellen, so kann im Feld "Datumsformat" der korrekte Aufbau angegeben werden. Das deutsche Datumsformat würde z. B. mit "dd.MM.yyyy" beschrieben. Eine vollständige Beschreibung der möglichen Angaben (englisch) gibt es hier: [https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns).
+
+#### Zeitzone
+Sollte die API ein Datum relativ zu einer Zeitzone angeben, die anders ist als die Zeitzone der Börse, dann kann es sein, dass die ausgelesenen Kurse aufgrund der Zeitverschiebung dem falschen Tag zugeschrieben werden. Ist dies der Fall, so lässt sich dies über das Feld "Datumszeitzone" korrigieren. Es akzeptiert statische Zeitverschiebungen der Form "+01:00", oder Zeitzonen IDs der Form "Europe/Berlin" (in diesem Fall ändert sich die Zeitverschiebung möglicherweise dynamisch je nach Sommer- oder Normalzeit).
+
+#### Faktor (für Kurse)
+Manche APIs geben Kurse möglicherweise in Cent statt in Euro oder Dollar an. In diesem Fall kann in diesem Feld ein Umrechnungsfaktor angegeben werden.

--- a/docs/en/how-to/downloading-historical-prices/json.md
+++ b/docs/en/how-to/downloading-historical-prices/json.md
@@ -121,3 +121,13 @@ Figure: JSON Quote Feed provider parameters. {class=pp-figure}
 
 For most services, one needs to register and obtain an API key, which is a unique identifier that authenticates the user and grants access to the service. While numerous financial services provide seemingly free API keys, their terms of use and long-term commitment often prove inadequate. Portfolio Performance has, for compatibility reasons, maintained several of these services in its list of Quote Feed providers; e.g. Alpha Vantage, eodhd, .... Although once considered excellent solutions, they have changed their offerings and are no longer as useful as free services. In practical terms, only Portfolio Report and Yahoo Finance can be recommended for a typical portfolio.
 
+### Further Fields
+
+#### Date Format
+Portfolio Performance automatically detects common date formats. This includes ISO date format (e.g. 2025-06-21) and UNIX timestamps (seconds since midnight 1970-01-01, UTC). If an API represents dates another way, it can be described using this field. E.g. for a date in month/day/year format, type in "MM/dd/yyyy". For a complete list of all possible identifier characters see [https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns).
+
+#### Date Time Zone
+If the API provides dates relative to a timezone different of the exchange's timezone, then it is possible that quotes are attributed to the wrong date due to time shift. In this case, you can correct this by supplying time zone information manually. This field accepts fixed offsets like "+01:00", or timezone IDs like "Europe/Berlin" (in this case the offset may change dynamically depending on daylight saving time).
+
+#### Factor (for quotes)
+Some APIs may provide quotes in cents/pennies instead of dollars/pounds/euros. Should this be the case, then this field can be used to provide a conversion factor.


### PR DESCRIPTION
The added content describes timezone behavior added with: https://github.com/portfolio-performance/portfolio/pull/4652

It also describes the date format and quote factor fields, which were not introduced with that PR, but were missing from the documentation.