### PR TITLE
Fix typos and improve Dutch language countries list in documentation

### DIFF
--- a/docs/en/concepts/cost-methodology.md
+++ b/docs/en/concepts/cost-methodology.md
@@ -1,7 +1,7 @@
 ---
 title: Cost principle 
 ---
-# Gains and Acquisiton Cost principle : FIFO vs Moving Average
+# Gains and Acquisition Cost principle : FIFO vs Moving Average
 
 To accurately assess realized and unrealized gains after the sale of a security, the sold amount and the remaining market value must be compared against the acquisition cost of the security. While this is straightforward in the case of a single purchase followed by a sale, various definitions and methodologies apply when multiple purchases and sales occur at different prices. Portfolio Performance calculates gains using two methodologies:
 

--- a/docs/en/getting-started/manage-portfolio/bonds.md
+++ b/docs/en/getting-started/manage-portfolio/bonds.md
@@ -50,7 +50,7 @@ A better, albeit somewhat unintuitive, approach is to record the transaction as 
 
     ![](../../images/mnu-transaction-dividend-vw-1.png)
 
-2. The interest payment (112.50 EUR) is reduced by the amount that was already recorded as tax on the purchase date (8.01 EUR). With a `Tansaction > Tax refund` that amount is refunded.
+2. The interest payment (112.50 EUR) is reduced by the amount that was already recorded as tax on the purchase date (8.01 EUR). With a `Transaction > Tax refund` that amount is refunded.
 3. The interest payment is reduced by the amount that was transferred to a separate account. The accrued interest amount then is transferred back to the original deposit account associated with the security.
 
 

--- a/docs/en/how-to/downloading-historical-prices/json.md
+++ b/docs/en/how-to/downloading-historical-prices/json.md
@@ -100,7 +100,7 @@ The response from the Yahoo server is a lengthy JSON document with all the histo
 
 The JSON response from above is an object, surrounded by { }. It contains meta data of the security, Unix timestamps from the two retrieved dates, and the different quote prices. You need a JSON path to retrieve the different values:
 
-- Error code of the reponse: `$.chart.error`
+- Error code of the response: `$.chart.error`
 - Metadata of the security: `$.chart.result[0].meta`. The result field is an array, even though there is only one element, probably because one can also ask data for multiple securities.
 - Symbol name: `$.chart.result[0].meta.symbol`
 - Requested dates: `$.chart.result[0].timestamp[*]`. The * serves as wildcard, facilitating the retrieval of all values.

--- a/docs/en/reference/help/preferences.md
+++ b/docs/en/reference/help/preferences.md
@@ -82,7 +82,7 @@ Figure: Settings for the language, country, and Java Locale. {class=align-right 
 
 Using the language drop-down menu, you can modify the user-interface language of the Portfolio Performance software, such as the menus and dialogs. Thirteen different languages are available: Deutsch (German), English, Español (Spanish), Français (French), Italiano (Italian), Nederlands (Dutch), Português (Portuguese), čeština (Czech), русский (Russian), Slovenská (Slovak), Polskie (Polish), 中文 (Chinese), and Dansk (Danish).
 
-The selected language will also affect the available country options. For instance, the Dutch language is spoken in seven countries: Aruba, Belgium, Carribean Netherlands, Curraçao, Sint Maarten, and Suriname.
+The selected language will also affect the available country options. For instance, the Dutch language is spoken in seven countries: Aruba, Belgium, Caribbean Netherlands, Curaçao, Netherlands, Sint Maarten, and Suriname.
 
 If English is selected as the UI language, several countries, including an option for Europe and World, can be chosen. The combination of language and country determines the Java Locale. For example, selecting the language "Dutch" and the country "Belgium" will result in the Java locale "nl_BE". Choosing "English" and "Europe" will produce the Java locale "en_150".
 

--- a/docs/en/reference/help/trouble-shooting.md
+++ b/docs/en/reference/help/trouble-shooting.md
@@ -6,7 +6,7 @@ changes:
     author: Nirus2000
     description:
       - Updated images
-      - Add OS informations
+      - Add OS information
 ---
 
 On rare occasions, the Portfolio Performance app may malfunction or crash. Under the **Help** menu, three key options can assist in such cases.

--- a/docs/en/reference/view/reports/performance/securities.md
+++ b/docs/en/reference/view/reports/performance/securities.md
@@ -64,7 +64,7 @@ Figure: Available fields Securities. {class=align-right style="width:30%"}
     - Div%/year: Also named Dividend rate of return per year = dividend payment / share price at time of dividend payment (average per year). The quote price of share-1 on dividend payment date (2022-12-15) was 18.898 EUR/share. The Div%/year = 30/
     - Number of dividend payments: Total number of dividend payments in the reporting period.
     - Date of last dividend payment: Date of the last dividend payment in the reporting period.
-    - Periodicity: The periodicity is estimated, based on the payments during the reporting period. `share-2` has no dividend payments; so the value is `none`. And, because, there is only 1 dividend payment for `share-1`, it is for the time being `unknown`. If there are multiple payments, the periodicity could be `anual`, `semi-anual`, `quarterly` or `monthly`.
+    - Periodicity: The periodicity is estimated, based on the payments during the reporting period. `share-2` has no dividend payments; so the value is `none`. And, because, there is only 1 dividend payment for `share-1`, it is for the time being `unknown`. If there are multiple payments, the periodicity could be `annual`, `semiannual`, `quarterly` or `monthly`.
 - Performance: By default, the TTWROR (cumulative), IRR, and Absolute Performance % is displayed.
     - TTWROR (annualized): see section on Performance calculation.
     - Capital Gains (FIFO, current holdings): For the securities in the portfolio at the end of the reporting period (current holdings) = Market value - Purchase value (FIFO). For `share-1`: 190.06 - 177.50 = 12.56 EUR. 
@@ -85,7 +85,7 @@ Figure: Available fields Securities. {class=align-right style="width:30%"}
     - Unrealized gains: The unrealized gains come from securities that are not yet sold. `share-2` hasn't been changed since the first purchase. So, the realized gains are zero EUR. The share has been purchased on September 2022 for 64 EUR (without taxes and fees). At the end of the reporting period (June 12, 2023) the market value is 11.76 EUR. The unrealized gains are 47.76 EUR. 
     - Currency gains / Unrealized Gains: same as above, except for unrealize gains.
 
-- Risk indicators (see [View > reports > Performance](../performance/index.md) for more info on these conepts):
+- Risk indicators (see [View > reports > Performance](../performance/index.md) for more info on these concepts):
 
     - Maximum Drawdown (MDD): A measure of the maximum loss that an investment has experienced during the reporting period; peak value - lowest value of the security. For share-1, this is 28.98%: 339 EUR on 2023-04-11 147 on 2021-01-30-- see article on [Investopedia](https://www.investopedia.com/terms/m/maximum-drawdown-mdd.asp)
     If an investment never lost a penny, the maximum drawdown would be zero. The worst possible maximum drawdown would be -100%, meaning the investment is completely worthless.

--- a/docs/en/reference/view/securities/all-securities.md
+++ b/docs/en/reference/view/securities/all-securities.md
@@ -148,7 +148,7 @@ Figure: Context menu of Historical Quotes in the information pane.{class=pp-figu
 
         ![](../images/contxt-mnu-all-securities-bottom-panel-hist-quotes-import-html-table.png)
 
-        For example, navigate to [https://www.finanzen.net/historische-kurse/nvidia](https://www.finanzen.net/historische-kurse/nvidia). You could also search for the security at the homepage. Enter a start and end date and a marketplace. NVIDIA is listed on XETRA. Click on Suchen (Search). Right-click the table and select View Page Source in the contaxt menu. Copy and paste everything in the PP.   
+        For example, navigate to [https://www.finanzen.net/historische-kurse/nvidia](https://www.finanzen.net/historische-kurse/nvidia). You could also search for the security at the homepage. Enter a start and end date and a marketplace. NVIDIA is listed on XETRA. Click on Suchen (Search). Right-click the table and select View Page Source in the context menu. Copy and paste everything in the PP.   
     - Create manually: This command is identical with the `Add` option above.
 
     - Export to CSV file ...: This command is identical with the `Export button` (top right).

--- a/docs/en/reference/view/securities/context-menu.md
+++ b/docs/en/reference/view/securities/context-menu.md
@@ -8,7 +8,7 @@ Figure: Context menu of a selected security.{class=align-right style="width:30%"
 
 The context menu of a security contains several additional options that are not available within the `view menu`. You can access the context menu by selecting a security or a security view (e.g., securities account) and right-clicking. A pop-up, as shown in Figure 1, will be displayed. The menu items Buy, Sell, Dividend, Tax Refund, Delivery (Inbound & Outbound) are already available in the [Transaction menu](../../transaction/index.md). Other items such as Events could be accessed in other views.
 
-## Documented elsewere
+## Documented elsewhere
 
 Several menu items do also appear in other menu's or views and are already documented in other sections of the documentation.
 - Buy, Sell, Dividend, Tax Refund, Delivery (Inbound), Delivery (Outbound) appear and are documented in the [Transaction menu](../../transaction/index.md).
@@ -36,7 +36,7 @@ Figure: Split stock wizard - step 1. {class=pp-figure}
 
 ![](images/split-stock-wizard-step-1.png)
 
-**Step 2** will show you the impact of this stock split on each transaction (buy, sell, delivery). The result is that the number of shares in your possesion will be changed, according to the split ratio. You can skip this step and maintain the transactions unchanged by unchecking the `Convert transactions` option. If there aren't any transactions, this step has no effect.
+**Step 2** will show you the impact of this stock split on each transaction (buy, sell, delivery). The result is that the number of shares in your possession will be changed, according to the split ratio. You can skip this step and maintain the transactions unchanged by unchecking the `Convert transactions` option. If there aren't any transactions, this step has no effect.
 
 As can be seen in Figure 2 and 4, there was only one buy transaction on January 3, 2022 (before the split date) of one share. Thus, from Janary 3, 2022 on, you will have 20 shares in your account, given that the default `Convert transactions` is checked.
 
@@ -64,7 +64,7 @@ Please note the difference between this chart and Figure 2. The rise in 2023 and
 
 ## Event
 
-An event is a kind of note that could be attached to a specific security on a particular date. They can be displayed on the historical price chart of that security. They are automatically inserted to mark occurences of stock split or dividend announcements, but can also be used for important stock news.
+An event is a kind of note that could be attached to a specific security on a particular date. They can be displayed on the historical price chart of that security. They are automatically inserted to mark occurrences of stock split or dividend announcements, but can also be used for important stock news.
 
 Events are generated automatically upon a stock split operation or a dividend announcement. Additionally, you can create your own custom event notes via the context menu of a security (see Figure 1) or the context menu in the Events tab of the information pane.
 


### PR DESCRIPTION
This PR corrects several typos and minor inaccuracies in the documentation:

- Fixes spelling errors such as "Carribean" → "Caribbean" and "Curraçao" → "Curaçao"
- Updates the list of countries where Dutch is spoken to include "Netherlands," making the total count consistent with the list